### PR TITLE
V0.34 - 2025 Spooki Release (New Mission Type, Random Zones, SP QOL changes, bugfixes)

### DIFF
--- a/Dynamic%20Horror%20Op.Malden/description.ext
+++ b/Dynamic%20Horror%20Op.Malden/description.ext
@@ -130,6 +130,7 @@ class CfgFunctions
 			class initLocation {};
 			class initSpawns {};
 			class spawnGroup {};
+			class spawnBoss {};
 			class spawnLight {};
 			class destroyLight {};
 		};

--- a/Dynamic%20Horror%20Op.Malden/description.ext
+++ b/Dynamic%20Horror%20Op.Malden/description.ext
@@ -94,6 +94,7 @@ class CfgFunctions
 		{
 			class heliInsert {};
 			class selectHeliLZ {};
+			class sendHeliToMarker {};
 		};
 		
 		class Init

--- a/Dynamic%20Horror%20Op.Malden/description.ext
+++ b/Dynamic%20Horror%20Op.Malden/description.ext
@@ -120,6 +120,7 @@ class CfgFunctions
 		{
 			class allEnemiesChase {};
 			class createTask {};
+			class createNewLocation {};
 			class farEnemiesCollapse {};
 			class findFarSpawns {};
 			class findLocation {};

--- a/Dynamic%20Horror%20Op.Malden/description.ext
+++ b/Dynamic%20Horror%20Op.Malden/description.ext
@@ -103,6 +103,7 @@ class CfgFunctions
 			class initDestroyItems {};
 			class initRetrieveItems {};
 			class randomMods {};
+			class setUnitLoadout {};
 			class spawnZoneProtection {};
 			class diagnostics {};
 		};

--- a/Dynamic%20Horror%20Op.Malden/functions/Base/fn_heliInsert.sqf
+++ b/Dynamic%20Horror%20Op.Malden/functions/Base/fn_heliInsert.sqf
@@ -9,7 +9,10 @@ if(getMarkerPos "LandingPosition" isEqualTo [0,0,0]) then {
 	"You must select an LZ first!" remoteExec["hint",MissionCommander];
 
 } else {
-	//send to lz
+	diag_log format ["Should be sending heli to %1",getMarkerPos "LandingPosition"];
+	["LandingPosition"] remoteExecCall ["DHO_fnc_sendHeliToMarker",2];
+
+/* 	//send to lz
 	_wp1 = heliGroup addWaypoint [getMarkerPos _marker, -1];
 	//set to transport unload and safe
 	_wp1 setWaypointType "TR UNLOAD";
@@ -20,6 +23,14 @@ if(getMarkerPos "LandingPosition" isEqualTo [0,0,0]) then {
 
 	//create move waypoint back to base
 	_wp2 = heliGroup addWaypoint [getMarkerPos "mainBase", -1];
-	_wp2 setWaypointStatements ["true", "transportHeli land 'LAND'"];
+	_wp2 setWaypointStatements ["true", "doStop transportHeli; transportHeli land 'LAND';"];
 
+	
+	//clear previous land command
+ 	_wp3 = heliGroup addWaypoint [getMarkerPos "mainBase", -1];
+	_wp3 setWaypointStatements ["true", "doStop transportHeli; transportHeli land 'NONE';"];
+	_wp3 setWaypointTimeout [60, 60, 60]; */
+
+
+	
 };

--- a/Dynamic%20Horror%20Op.Malden/functions/Base/fn_sendHeliToMarker.sqf
+++ b/Dynamic%20Horror%20Op.Malden/functions/Base/fn_sendHeliToMarker.sqf
@@ -1,0 +1,43 @@
+params["_marker"];
+
+//send to lz
+_wp1 = heliGroup addWaypoint [getMarkerPos _marker, -1];
+//set to transport unload and safe
+_wp1 setWaypointType "TR UNLOAD";
+_wp1 setWaypointBehaviour "CARELESS";
+//ensure heli waits until its unloaded with DEBUG***
+_wp1 setWaypointStatements ["count (crew transportHeli) < 3", "diag_log 'Players dropped off by heli'; MissionCommander synchronizeObjectsAdd [supportRequester];"];
+
+
+//create move waypoint back to base
+_wp2 = heliGroup addWaypoint [getMarkerPos "mainBase", -1];
+//_wp2 setWaypointStatements ["true", "doStop transportHeli; transportHeli landAt [getMarkerPos 'mainBase', 'LAND'];"];
+_wp2 setWaypointStatements ["true", "doStop transportHeli; transportHeli land 'LAND';"];
+
+fn_replaceCrew = {
+	params["_heli"];
+	
+	{
+		if (!isPlayer _x) then {
+			deleteVehicle _x;
+		};
+	} forEach crew _heli;
+	
+	private _tempGroup = createGroup [west, true];
+	
+	private _tempUnit = _tempGroup createUnit ["B_Helipilot_F", getMarkerPos "mainBase",[], 0, "NONE"];
+	_tempUnit moveInDriver _heli;
+	private _tempUnit2 = _tempGroup createUnit ["B_Helipilot_F", getMarkerPos "mainBase",[], 0, "NONE"];
+	_tempUnit2 moveInTurret [_heli, [0]];
+	//_tempUnit2 moveInAny _heli;
+
+	missionNamespace setVariable ["heliGroup", _tempGroup];
+	
+};
+
+
+//clear previous land command
+ _wp3 = heliGroup addWaypoint [getMarkerPos "mainBase", -1];
+_wp3 setWaypointStatements ["true", "doStop transportHeli; transportHeli land 'NONE'; transportHeli engineOn false; [transportHeli] call fn_replaceCrew;"];
+//_wp3 setWaypointStatements ["true", "doStop transportHeli; transportHeli landAt [getMarkerPos 'mainBase', 'NONE']"];
+_wp3 setWaypointTimeout [30, 30, 30];

--- a/Dynamic%20Horror%20Op.Malden/functions/Init/fn_setUnitLoadout.sqf
+++ b/Dynamic%20Horror%20Op.Malden/functions/Init/fn_setUnitLoadout.sqf
@@ -1,0 +1,44 @@
+/*
+	Description: This script saves the calling player's loadout, then takes the loadout from a targeted unit and 
+		applies it the calling player so they can modify the loadout in the arsenal. Finally, when the arsenal is
+		closed, the modified loadout is applied to the targeted unit and the player's loadout is restored.
+		
+	Use: This script is called by an addAction applied to the friendly AI units at mission start
+	
+	Called by: An addAction defined on the targetUnit i.e. 
+		_actionID = this addAction [
+			"Modify Loadout", {
+				[_this_select 0, _this select 1, _this select 2, _this select 3]] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]
+			}
+		]; 
+		
+	Calls: none
+	Called on: Calling player locally
+	Parameters: 0: targetted unit
+				1: calling player (local)
+				2: unused
+				3: unused
+	Return: none
+*/
+
+params ["_currentUnit", "_currentPlayer", "_actionId", "_arguments"];
+
+//save loadout and target unit to player for reference within the eventhandler
+_currentPlayer setVariable ["_tempLoadout", getUnitLoadout _currentPlayer];
+_currentPlayer setVariable ["_tempUnit", _currentUnit];
+
+//add EH to apply changes made in arsenal
+[missionNamespace,"arsenalClosed", {
+	_currentUnit = player getVariable ["_tempUnit", []];
+	_tempLoadout = player getVariable ["_tempLoadout", []];
+	_currentUnit setUnitLoadout (getUnitLoadout player);
+    player setUnitLoadout _tempLoadout; 
+	
+	//remove this EH
+	[missionNamespace,"arsenalClosed", _thisScriptedEventHandler] call BIS_fnc_removeScriptedEventHandler;
+}] call BIS_fnc_addScriptedEventHandler;
+
+//after EH is applied, change to target unit's loadout and open arsenal
+_currentPlayer setUnitLoadout (getUnitLoadout _currentUnit);
+["Open", [true]] call BIS_fnc_arsenal;
+

--- a/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_createNewLocation.sqf
+++ b/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_createNewLocation.sqf
@@ -1,0 +1,48 @@
+/*
+	Description: This script creates new location objects in random locations to enable missions outside of just named towns.
+		
+	Use: This script is called by DHO_fnc_findLocation.sqf upon mission creation, but may have use to create new dynamic
+		zones in the future.
+	
+	Called by: Within DHO_fnc_findLocation.sqf. Example:
+		[] spawn DHO_fnc_createNewLocation;
+		
+	Calls: none
+	Called on: Server only
+	Parameters: 0: 
+				1: 
+				2: unused
+				3: unused
+	Return: new Location object
+*/
+
+//get a location not near any other locations
+private _newPos = [nil, ["water"], {_this distance (nearestLocation[_this, ['NameCityCapital','NameCity','NameVillage','NameLocal','rockArea','ViewPoint']]) > (NearRadius/2) }] call BIS_fnc_randomPos;
+
+private _nearestLoc = nearestLocation[[_newPos select 0, _newPos select 1], ['NameCityCapital','NameCity','NameVillage','NameLocal','rockArea','ViewPoint']];
+
+//get name for logging
+private _nearLocName = '';
+if (text _nearestLoc == "") then {
+	_nearLocName = "ROCK OR LOOKOUT";
+} else {
+	_nearLocName = text _nearestLoc;
+};
+
+diag_log format ['** Random location found at %1. Distance to nearest loc %2 is %3',_newPos, _nearLocName, _newPos distance _nearestLoc];
+
+private _newLoc = createLocation ["FlatArea", _newPos, 50, 50];
+_newLoc setText format ['Area near %1', _nearLocName];
+
+//***DEBUG 
+/*
+_newLoc setText format ['Area near %1', _nearLocName];
+_debugMarker = createMarker["TEST TEST", _newPos];
+_debugMarker setMarkerShape "ELLIPSE";
+_debugMarker setMarkerSize [100,100];
+_debugMarker setMarkerColor "ColorRed";
+_debugMarker setMarkerAlpha 0.5;
+_debugMarker setMarkerBrush "DIAGGRID"; */
+
+//return new area
+_newLoc;

--- a/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_createTask.sqf
+++ b/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_createTask.sqf
@@ -237,8 +237,11 @@ switch (_missionType) do
 	};//end case 2 destroy object mission
 	case 3: {//kill boss
 		//spawn boss unit
-		private _spawnLocs = _logicObject getVariable _nearSpawns;
+		private _spawnLocs = _logicObject getVariable "_nearSpawns";
+		private _spawnPos = selectRandom _spawnLocs;
 		//***TODO: check locs exist and wait if not
+		//diag_log format ["Spawn selected for boss at %1 from a list of %2 nearspawns", _spawnPos, count _spawnLocs];
+		
 		private _bossGroup = [_spawnLocs] call DHO_fnc_spawnBoss;
 		private _bossUnit = leader _bossGroup;
 		
@@ -246,13 +249,20 @@ switch (_missionType) do
 		_logicObject setVariable ["_bossUnit", _bossUnit];
 		
 		//object preview image
-		private _itemPhoto = getText (configfile >> "CfgVehicles" >> typeOf _retrieveObject >> "editorPreview");
-		_taskString = format ["%1",formatText [format ["<img image='%1'/>", _itemPhoto]]];
+		private _bossPhoto = getText (configfile >> "CfgVehicles" >> typeOf _bossUnit >> "editorPreview");
+		_taskString = '';
+		if (_bossPhoto == '') then {
+			_taskString = composeText ['<br/>*** ERROR, NO IMAGE ON FILE ***'];
+		} else {
+			_taskString = format ["%1",formatText [format ["<img image='%1'/>", _bossPhoto]]];
+		};
+		
+		diag_log format ["Task String = %1", _taskString];
 		
 		//create a task for this mission
 		[west, _taskName, [
 			format ["We have confirmed reports of a powerful entity '%1' operating near %2. Hunt it down and destroy it. You can see what it looks like below: %3",getText (configFile >> "cfgVehicles" >> typeOf _bossUnit >> "displayName"),text _selectedLoc, _taskString], 
-			format ["Destroy the '%1'", getText (configFile >> "cfgVehicles" >> typeOf _retrieveObject >> "displayName")], 
+			format ["Destroy the '%1' ", getText (configFile >> "cfgVehicles" >> typeOf _bossUnit >> "displayName")], 
 			_locationName], 
 			getPos _bossUnit, 
 			"AUTOASSIGNED"] call BIS_fnc_taskCreate;
@@ -262,7 +272,7 @@ switch (_missionType) do
 		_taskTrigger setTriggerArea [10, 10, 0, false];
 		_taskTrigger setTriggerActivation ["EAST", "PRESENT", false];
 
-		private _trigStatement1 = format ["isNull (%1 getVariable '_bossUnit')", _logicObject];
+		private _trigStatement1 = format ["isNull (%1 getVariable '_bossUnit') || lifeState (%1 getVariable '_bossUnit') == 'DEAD'", _logicObject];
 		private _trigStatement2 = format ["LastLocation = getPos %1; ['%2', 'SUCCEEDED'] call BIS_fnc_taskSetState; CompletedLocations = CompletedLocations + 1; publicVariable 'CompletedLocations'; publicVariable 'LastLocation';", _logicObject, _taskName];
 
 		_taskTrigger setTriggerStatements [

--- a/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_createTask.sqf
+++ b/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_createTask.sqf
@@ -51,7 +51,7 @@ switch (_missionType) do
 		//add HQ calls
 		//TODO***
 	
-	};
+	};//end case 0 purge mission
 	case 1: { //find item missison
 	
 		//select item from list
@@ -151,7 +151,7 @@ switch (_missionType) do
 		
 		//***DEBUG
 		diag_log format["Find item selected. Part 5, task object is in state %1", _taskName call BIS_fnc_taskState];
-	};
+	};//end case 1 retrieve object mission
 	case 2: {//destroy object
 		//select item from list
 		private _destroyItem = selectRandom DestroyItems;
@@ -234,7 +234,45 @@ switch (_missionType) do
 		_taskTrigger attachTo [_destroyObject];
 		//{_x inArea thisTrigger} count allMissionObjects "#explosion" > 0
 
-	};
+	};//end case 2 destroy object mission
+	case 3: {//kill boss
+		//spawn boss unit
+		private _spawnLocs = _logicObject getVariable _nearSpawns;
+		//***TODO: check locs exist and wait if not
+		private _bossGroup = [_spawnLocs] call DHO_fnc_spawnBoss;
+		private _bossUnit = leader _bossGroup;
+		
+		//save unit to logicObject for later use
+		_logicObject setVariable ["_bossUnit", _bossUnit];
+		
+		//object preview image
+		private _itemPhoto = getText (configfile >> "CfgVehicles" >> typeOf _retrieveObject >> "editorPreview");
+		_taskString = format ["%1",formatText [format ["<img image='%1'/>", _itemPhoto]]];
+		
+		//create a task for this mission
+		[west, _taskName, [
+			format ["We have confirmed reports of a powerful entity '%1' operating near %2. Hunt it down and destroy it. You can see what it looks like below: %3",getText (configFile >> "cfgVehicles" >> typeOf _bossUnit >> "displayName"),text _selectedLoc, _taskString], 
+			format ["Destroy the '%1'", getText (configFile >> "cfgVehicles" >> typeOf _retrieveObject >> "displayName")], 
+			_locationName], 
+			getPos _bossUnit, 
+			"AUTOASSIGNED"] call BIS_fnc_taskCreate;
+		
+		//trigger to check if boss is destroyed
+		private _taskTrigger = createTrigger ["EmptyDetector", getPos _bossUnit];
+		_taskTrigger setTriggerArea [10, 10, 0, false];
+		_taskTrigger setTriggerActivation ["EAST", "PRESENT", false];
+
+		private _trigStatement1 = format ["isNull (%1 getVariable '_bossUnit')", _logicObject];
+		private _trigStatement2 = format ["LastLocation = getPos %1; ['%2', 'SUCCEEDED'] call BIS_fnc_taskSetState; CompletedLocations = CompletedLocations + 1; publicVariable 'CompletedLocations'; publicVariable 'LastLocation';", _logicObject, _taskName];
+
+		_taskTrigger setTriggerStatements [
+			_trigStatement1,
+			_trigStatement2,
+			""
+		];
+		
+		diag_log format ["Boss mission created in zone %1. Boss type: %2",_locationName, getText (configFile >> "cfgVehicles" >> typeOf _bossUnit >> "displayName")];
+	};//end case 3 kill boss mission
 };
 
 //wait until all spawns are complete

--- a/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_findLocation.sqf
+++ b/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_findLocation.sqf
@@ -11,6 +11,7 @@ private _village = true;
 private _nameLocal = true;
 private _rockArea = true;
 private _viewPoint = true;
+private _flatArea = true;
 
 //array of location names to exclude from searach
 //private _dontSearch = ["Elektrozavodsk","Chernogorsk","Balota","Drakon","Factory","Airstrip"];
@@ -36,6 +37,10 @@ if (_rockArea) then {
 if (_viewPoint) then {
 	_searchTypes pushBack "ViewPoint";
 };
+if (_flatArea) then {
+	_searchTypes pushBack "FlatArea";
+};
+
 
 //log for debug***
 //diag_Log format ["Current area types to search = %1",_searchTypes];
@@ -83,6 +88,15 @@ _debugMarker setMarkerSize [NearRadius,NearRadius];
 _debugMarker setMarkerColor "ColorRed";
 _debugMarker setMarkerAlpha 0.5;
 _debugMarker setMarkerBrush "DIAGGRID";
+
+/* //if location is a randomly generated one, then set the name
+if (text _selectedLoc == "") then {
+	//get nearest named location
+	private _nearbyLocName = nearestLocation[[locationPosition _selectedLoc select 0, locationPosition _selectedLoc select 1], ['NameCityCapital','NameCity','NameVillage','NameLocal']];
+	
+	//set location name
+	_selectedLoc setText format ['Area near %1', _nearbyLocName];
+}; */
 
 //debug***
 diag_log format ["Final %1 Location is %2 at %3", _locName, text _selectedLoc, _selectedLoc];

--- a/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_initLocation.sqf
+++ b/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_initLocation.sqf
@@ -4,7 +4,7 @@ params ["_selectedLoc","_locIndex"];
 	//select mission type
 	//0=clear area, 1=find objects, 2=destroy object, 3=kill boss, 4=rescue
 	//MissionType = floor(random(4));
-	_missionType = selectRandom[0,1,2];
+	_missionType = selectRandom[0,1,2,3];
 	//DEBUG***
 	//MissionType = 1;
 	

--- a/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_initLocation.sqf
+++ b/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_initLocation.sqf
@@ -6,7 +6,7 @@ params ["_selectedLoc","_locIndex"];
 	//MissionType = floor(random(4));
 	_missionType = selectRandom[0,1,2,3];
 	//DEBUG***
-	//MissionType = 1;
+	//_missionType = 3;
 	
 	//select enemy types
 	//0=all, 1=fantasy, 2=sci fi, 3=cryptid, 4=stalker/post-apoc, 5=undead

--- a/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_initLocation.sqf
+++ b/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_initLocation.sqf
@@ -44,6 +44,30 @@ params ["_selectedLoc","_locIndex"];
 	//waitUntil{sleep 1;scriptDone _spawnInit};
 	waitUntil{sleep 1; count (units east inAreaArray (format ["selectedLocation%1",_locIndex])) > 5;};
 	
+	//create a trigger that reenables simulation when players enter area (bug workaround)
+	//private _units = thisTrigger list select { side _x == east && alive _x };
+	//private _units = units east select { _x inArea thisTrigger && alive _x };
+	private _locTrigger = createTrigger ["EmptyDetector", position _selectedLoc];
+	_locTrigger setTriggerArea [NearRadius * 4,NearRadius * 4,0,false];
+	_locTrigger setTriggerActivation ["ANYPLAYER", "PRESENT", false];
+	_locTrigger setTriggerType "NONE";
+	_locTrigger setTriggerTimeout [0, 0, 0, true];
+	_locTrigger setTriggerStatements [
+		"this",
+		"
+			{
+				private _units = allUnits select { _x inArea thisTrigger};
+				{
+					_x enableDynamicSimulation false;
+					_x enableSimulationGlobal true;
+				} forEach _units;
+			} remoteExec ['call', 0];
+		",
+		""
+	];
+	//*** DEBUG***
+	//diag_log format ['*** TRIGGER CREATED AT %1', getPos _locTrigger];
+
 	
 	//generate tasks
 	[_selectedLoc,_locIndex,_missionType] spawn DHO_fnc_createTask;

--- a/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_spawnBoss.sqf
+++ b/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_spawnBoss.sqf
@@ -70,6 +70,7 @@ diag_log format ["Boss unit %1 spawning at %2",_newUnitType,_spawnPos];
 	
 private _newUnit = _newGroup createUnit [_newUnitType, _spawnPos, [], 5, "NONE"];
 [_newUnit] joinSilent _newGroup;
+_newUnit enableDynamicSimulation true;
 
 //delete temp unit
 deleteVehicle _tempUnit;

--- a/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_spawnBoss.sqf
+++ b/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_spawnBoss.sqf
@@ -58,8 +58,8 @@ while {(count _filteredBossTypes < 1) && (_maxBossLevel > 0)} do {
 };
 
 //if still no boss type was available, then exit with an error
-if (count _filteredBossTypes < 1) then {
-	exitWith{diag_log format ["*** ERROR: Boss Spawn unable to find any units at %1 Boss level or below!", ceil(count allPlayers / 4) + _difficultyModifier];};
+if (count _filteredBossTypes < 1) exitWith {
+	diag_log format ["*** ERROR: Boss Spawn unable to find any units at %1 Boss level or below!", ceil(count allPlayers / 4) + _difficultyModifier]
 };
 
 //select the boss unit from all boss units defined by mods

--- a/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_spawnBoss.sqf
+++ b/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_spawnBoss.sqf
@@ -1,0 +1,77 @@
+//0 = NearSpawns/BuildingSpawns/FarSpawns
+// example [NearSpawns] execVM "functions\Zones\fn_spawnBoss.sqf";
+// example [,NearSpawns] call DHO_fnc_spawnBoss;
+params["_spawnLocs"];
+
+//debug***
+//diag_log format ["Spawning new group of %1 units", _numToSpawn];
+
+private _spawnPos = selectRandom _spawnLocs;
+
+//group to hold new units
+private _newGroup = createGroup east;
+_newGroup enableDynamicSimulation true;
+
+//temp unit to ensure side is set to east
+private _tempUnit = _newGroup createUnit ["O_Survivor_F", _spawnPos, [], 5, "NONE"];
+
+//check player count to ensure boss is not too powerful
+DifficultyParam = ["DifficultyParam", 2] call BIS_fnc_getParamValue;
+private _difficultyModifier = 0;
+
+switch (DifficultyParam) do {
+	case 0:{
+		_difficultyModifier = -1;
+	};
+	case 1:{
+		_difficultyModifier = 0;
+	};
+	case 2:{
+		_difficultyModifier = 1;
+	};
+	case 3:{
+		_difficultyModifier = 2;
+	};
+};	
+
+_maxBossLevel = ceil(count allPlayers / 4) + _difficultyModifier;
+
+//ensure max level is at least 1
+if (_maxBossLevel < 1) then {
+	_maxBossLevel = 1;
+};
+
+//get list of boss units that meet level requirement
+_filteredBossTypes = [];
+
+while {(count _filteredBossTypes < 1) && (_maxBossLevel > 0)} do {
+	{
+		if (_x select 1 == _maxBossLevel) then {
+			_filteredBossTypes pushBack _x;
+		};
+	} forEach EnemySpawnBoss;
+
+	//if no bosses are available at the given level, check other levels
+	if (count _filteredBossTypes < 1) then {
+		_maxBossLevel = _maxBossLevel - 1;
+	};
+};
+
+//if still no boss type was available, then exit with an error
+if (count _filteredBossTypes < 1) then {
+	exitWith{diag_log format ["*** ERROR: Boss Spawn unable to find any units at %1 Boss level or below!", ceil(count allPlayers / 4) + _difficultyModifier];};
+};
+
+//select the boss unit from all boss units defined by mods
+_newUnitType = selectRandom _filteredBossTypes select 0;
+
+//finally, spawn boss unit
+diag_log format ["Boss unit %1 spawning at %2",_newUnitType,_spawnPos];
+	
+private _newUnit = _newGroup createUnit [_newUnitType, _spawnPos, [], 5, "NONE"];
+[_newUnit] joinSilent _newGroup;
+
+//delete temp unit
+deleteVehicle _tempUnit;
+
+_newGroup;

--- a/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_spawnGroup.sqf
+++ b/Dynamic%20Horror%20Op.Malden/functions/Zones/fn_spawnGroup.sqf
@@ -24,6 +24,7 @@ for "_i" from 0 to (_numToSpawn - 1) do {
 	
 	private _newUnit = _newGroup createUnit [_newUnitType, _spawnPos, [], 5, "NONE"];
 	[_newUnit] joinSilent _newGroup;
+	_newUnit enableDynamicSimulation true;
 	
 	//delay for computer's sake
 	sleep 0.1;

--- a/Dynamic%20Horror%20Op.Malden/init.sqf
+++ b/Dynamic%20Horror%20Op.Malden/init.sqf
@@ -113,9 +113,25 @@ if (isServer) then {
 		//spawn the units and add to the player group
 		for [{ _i = 0 }, { _i < _numUnits }, { _i = _i + 1 }] do {
 			private _currentSpawn = [MissionCommander, 0, 1, 1] call BIS_fnc_findSafePos;
-			private _newUnit = group1 createUnit [_unitTypes select [_i], _spawnPos, [], 5, "NONE"];
+			private _newUnit = group1 createUnit [_unitTypes select _i, MissionCommander, [], 1, "NONE"];
+			
 			[_newUnit] joinSilent group1;
-		};
+			
+			//addAction to modify unit loadout
+			_actionID = _newUnit addAction [
+				"Modify Loadout", 
+				{
+					[_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1];
+				},
+				nil,
+				1.5,
+				true,
+				true,
+				"",
+				"(_target distance (getMarkerPos 'mainBase')) < 500"
+			];//end addAction
+			
+		};//end for loop
 	};
 	
 	//if more players, increase NearRadius

--- a/Dynamic%20Horror%20Op.Malden/init.sqf
+++ b/Dynamic%20Horror%20Op.Malden/init.sqf
@@ -130,6 +130,13 @@ if (isServer) then {
 		[[PrefEnemy1,PrefEnemy2,PrefEnemy3]] call DHO_fnc_checkSpecifiedMods;
 	};
 	
+	//create some randomly generated zones in the wilderness = 10% of total location
+	private _numLocsToGen = ceil(0.1 * (count nearestLocations [[worldSize/2, worldSize/2,0],['NameCityCapital','NameCity','NameVillage','NameLocal','rockArea','ViewPoint'],worldSize/2]));
+	for [{ private _i = 0 }, { _i < _numLocsToGen }, { _i = _i + 1 }] do {
+		[] spawn DHO_fnc_createNewLocation;
+	};	
+	
+	
 	for [{ private _i = 0 }, { _i < NumLocations }, { _i = _i + 1 }] do {
 		//***DEBUG
 		diag_log format ["Generating location %1", _i];

--- a/Dynamic%20Horror%20Op.Malden/init.sqf
+++ b/Dynamic%20Horror%20Op.Malden/init.sqf
@@ -279,3 +279,5 @@ if (isServer) then {
 //add actions to insert helicopter
 transportHeli addAction ["* Select LZ", "functions\Base\fn_selectHeliLZ.sqf", nil, 1.5, true, true, "", "_this == missionCommander && !(isEngineOn _target)", 10, false];
 transportHeli addAction ["** Begin Insertion", "functions\Base\fn_heliInsert.sqf", nil, 1.5, true, true, "", "_this == missionCommander && !(isEngineOn _target)", 10, false];
+//transportHeli addAction ["* Select LZ", {[] remoteExec ["selectHeliLZ",2]}, nil, 1.5, true, true, "", "_this == missionCommander && !(isEngineOn _target)", 10, false];
+//transportHeli addAction ["** Begin Insertion", {[] remoteExec ["heliInsert",2]}, nil, 1.5, true, true, "", "_this == missionCommander && !(isEngineOn _target)", 10, false];

--- a/Dynamic%20Horror%20Op.Malden/init.sqf
+++ b/Dynamic%20Horror%20Op.Malden/init.sqf
@@ -84,6 +84,40 @@ if (isServer) then {
 	//generate possible items to Destroy in missiontype 2
 	call DHO_fnc_initDestroyItems;
 	
+	//if a single player launches in MP or on dedi, generate a squad
+	if (isMultiplayer && count allPlayers == 1) then {
+		
+		//types of units to spawn in team
+		private _unitTypes = [
+			'B_Soldier_F',
+			'B_medic_F',
+			'B_Soldier_GL_F',
+			'B_soldier_AR_F',
+			'B_soldier_M_F',
+			'B_soldier_LAT_F',
+			'B_soldier_AR_F',
+			'B_Soldier_F'
+		];
+		
+		//number of teammates depends on difficulty
+		private _numUnits = 8;
+		switch (DifficultyParam) do {
+			case 2:{
+				_numUnits = 6;
+			};
+			case 3:{
+				_numUnits = 4;
+			};
+		};
+		
+		//spawn the units and add to the player group
+		for [{ _i = 0 }, { _i < _numUnits }, { _i = _i + 1 }] do {
+			private _currentSpawn = [MissionCommander, 0, 1, 1] call BIS_fnc_findSafePos;
+			private _newUnit = group1 createUnit [_unitTypes select [_i], _spawnPos, [], 5, "NONE"];
+			[_newUnit] joinSilent group1;
+		};
+	};
+	
 	//if more players, increase NearRadius
 	if(count allPlayers > 4) then {
 		NearRadius = 200 + 10*((count allPlayers)-4);

--- a/Dynamic%20Horror%20Op.Malden/init.sqf
+++ b/Dynamic%20Horror%20Op.Malden/init.sqf
@@ -84,8 +84,20 @@ if (isServer) then {
 	//generate possible items to Destroy in missiontype 2
 	call DHO_fnc_initDestroyItems;
 	
-	//if a single player launches in MP or on dedi, generate a squad
-	if (isMultiplayer && count allPlayers == 1) then {
+	//if in SP, delete group 2 and remaining nonplayer units in group 1
+	if(!isMultiplayer) then {
+		{
+			deleteVehicle _x;
+		} forEach units group2;
+		{
+			if(!(isPlayer _x)) then {
+				deleteVehicle _x;
+			};
+		} forEach units group1;
+	};
+	
+	//if a single player launches in SP, MP, or on dedi, generate a squad
+	if (count allPlayers == 1) then {
 		
 		//types of units to spawn in team
 		private _unitTypes = [
@@ -101,12 +113,16 @@ if (isServer) then {
 		
 		//number of teammates depends on difficulty
 		private _numUnits = 8;
-		switch (DifficultyParam) do {
-			case 2:{
-				_numUnits = 6;
-			};
-			case 3:{
-				_numUnits = 4;
+		
+		//check if parameters are possible
+		if (isMultiplayer) then {
+			switch (DifficultyParam) do {
+				case 2:{
+					_numUnits = 6;
+				};
+				case 3:{
+					_numUnits = 4;
+				};
 			};
 		};
 		
@@ -133,7 +149,7 @@ if (isServer) then {
 			
 			//addAction to modify unit loadout and run on all clients
 			[_newUnit, [
-				"Modify Loadout", 
+				"Modify Unit Loadout", 
 				{
 					[_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1];
 				},
@@ -220,13 +236,6 @@ if (isServer) then {
 	
 	//create spawn protection zone to deter anomalous spawn camping
 	[300,5] call DHO_fnc_spawnZoneProtection;
-	
-	//if single player, delete group 2
-	if(!isMultiplayer) then {
-		{
-			deleteVehicle _x;
-		} forEach units group2;
-	};
 
 	//Start polling diagnostic
 	[] spawn DHO_fnc_diagnostics;

--- a/Dynamic%20Horror%20Op.Malden/init.sqf
+++ b/Dynamic%20Horror%20Op.Malden/init.sqf
@@ -117,7 +117,7 @@ if (isServer) then {
 			
 			[_newUnit] joinSilent group1;
 			
-			//addAction to modify unit loadout
+			/* //addAction to modify unit loadout
 			_actionID = _newUnit addAction [
 				"Modify Loadout", 
 				{
@@ -129,7 +129,21 @@ if (isServer) then {
 				true,
 				"",
 				"(_target distance (getMarkerPos 'mainBase')) < 500"
-			];//end addAction
+			];//end addAction */
+			
+			//addAction to modify unit loadout and run on all clients
+			[_newUnit, [
+				"Modify Loadout", 
+				{
+					[_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1];
+				},
+				nil,
+				1.5,
+				true,
+				true,
+				"",
+				"(_target distance (getMarkerPos 'mainBase')) < 500"
+			]] remoteExec ['addAction',0];
 			
 		};//end for loop
 	};

--- a/Dynamic%20Horror%20Op.Malden/mission.sqm
+++ b/Dynamic%20Horror%20Op.Malden/mission.sqm
@@ -12,7 +12,7 @@ class EditorData
 	};
 	class ItemIDProvider
 	{
-		nextID=209;
+		nextID=210;
 	};
 	class MarkerIDProvider
 	{
@@ -20,18 +20,18 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=55;
+		nextID=56;
 	};
 	class Camera
 	{
-		pos[]={8050.0864,35.549629,10153.071};
-		dir[]={0.57772255,-0.63397664,0.51411241};
-		up[]={0.47360325,0.77335155,0.4214578};
-		aside[]={0.66478461,-7.7183358e-08,-0.74703616};
+		pos[]={8080.1504,56.334846,10155.967};
+		dir[]={-0.68940312,-0.64772332,0.32437009};
+		up[]={-0.58609909,0.76186359,0.27576444};
+		aside[]={0.42574677,-1.5820842e-07,0.904863};
 	};
 };
 binarizationWanted=0;
-sourceName="dynamic%20horror%20op";
+sourceName="Dynamic%20Horror%20Op";
 addons[]=
 {
 	"A3_Characters_F",
@@ -370,7 +370,7 @@ class Mission
 	};
 	class Entities
 	{
-		items=78;
+		items=79;
 		class Item0
 		{
 			dataType="Group";
@@ -390,7 +390,6 @@ class Mission
 					flags=7;
 					class Attributes
 					{
-						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						description="Mission Commander [Required]";
 						isPlayer=1;
 						isPlayable=1;
@@ -441,7 +440,6 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=149;
@@ -461,7 +459,6 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=150;
@@ -481,7 +478,6 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=151;
@@ -501,7 +497,6 @@ class Mission
 					class Attributes
 					{
 						rank="SERGEANT";
-						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=152;
@@ -521,7 +516,6 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=153;
@@ -541,7 +535,6 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=154;
@@ -561,7 +554,6 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=155;
@@ -3670,7 +3662,6 @@ class Mission
 					flags=7;
 					class Attributes
 					{
-						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=168;
@@ -3689,7 +3680,6 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=169;
@@ -3710,7 +3700,6 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=170;
@@ -3730,7 +3719,6 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=171;
@@ -3750,7 +3738,6 @@ class Mission
 					class Attributes
 					{
 						rank="SERGEANT";
-						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=172;
@@ -3770,7 +3757,6 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
-						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=173;
@@ -3790,7 +3776,6 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=174;
@@ -3810,7 +3795,6 @@ class Mission
 					class Attributes
 					{
 						skill=0.40000001;
-						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=175;
@@ -4022,16 +4006,83 @@ class Mission
 				nAttributes=1;
 			};
 		};
+		class Item78
+		{
+			dataType="Logic";
+			class PositionInfo
+			{
+				position[]={8040.6611,29.59313,10192.927};
+				angles[]={0.00077204045,0,6.2824135};
+			};
+			id=209;
+			type="SupportProvider_Virtual_Transport";
+			class CustomAttributes
+			{
+				class Attribute0
+				{
+					property="SupportProvider_Virtual_Transport_BIS_SUPP_filter";
+					expression="_this setVariable ['BIS_SUPP_filter',_value,true];";
+					class Value
+					{
+						class data
+						{
+							singleType="STRING";
+							value="Side";
+						};
+					};
+				};
+				class Attribute1
+				{
+					property="SupportProvider_Virtual_Transport_BIS_SUPP_vehicles";
+					expression="_this setVariable ['BIS_SUPP_vehicles',_value,true];";
+					class Value
+					{
+						class data
+						{
+							singleType="STRING";
+							value="[]";
+						};
+					};
+				};
+				class Attribute2
+				{
+					property="SupportProvider_Virtual_Transport_BIS_SUPP_vehicleInit";
+					expression="_this setVariable ['BIS_SUPP_vehicleInit',_value,true];";
+					class Value
+					{
+						class data
+						{
+							singleType="STRING";
+							value="";
+						};
+					};
+				};
+				class Attribute3
+				{
+					property="SupportProvider_Virtual_Transport_BIS_SUPP_cooldown";
+					expression="_this setVariable ['BIS_SUPP_cooldown',_value,true];";
+					class Value
+					{
+						class data
+						{
+							singleType="SCALAR";
+							value=0;
+						};
+					};
+				};
+				nAttributes=4;
+			};
+		};
 	};
 	class Connections
 	{
 		class LinkIDProvider
 		{
-			nextID=13;
+			nextID=12;
 		};
 		class Links
 		{
-			items=13;
+			items=12;
 			class Item0
 			{
 				linkID=0;
@@ -4135,8 +4186,8 @@ class Mission
 			class Item10
 			{
 				linkID=10;
-				item0=144;
-				item1=39;
+				item0=146;
+				item1=145;
 				class CustomData
 				{
 					type="Sync";
@@ -4145,17 +4196,7 @@ class Mission
 			class Item11
 			{
 				linkID=11;
-				item0=144;
-				item1=145;
-				class CustomData
-				{
-					type="Sync";
-				};
-			};
-			class Item12
-			{
-				linkID=12;
-				item0=146;
+				item0=209;
 				item1=145;
 				class CustomData
 				{

--- a/Dynamic%20Horror%20Op.Malden/mission.sqm
+++ b/Dynamic%20Horror%20Op.Malden/mission.sqm
@@ -20,14 +20,14 @@ class EditorData
 	};
 	class LayerIndexProvider
 	{
-		nextID=54;
+		nextID=55;
 	};
 	class Camera
 	{
-		pos[]={8145.479,113.01456,10168.846};
-		dir[]={-0.6979112,-0.71552491,0.030820562};
-		up[]={-0.71483094,0.69858384,0.031567741};
-		aside[]={0.044118203,2.1696906e-08,0.99902803};
+		pos[]={8050.0864,35.549629,10153.071};
+		dir[]={0.57772255,-0.63397664,0.51411241};
+		up[]={0.47360325,0.77335155,0.4214578};
+		aside[]={0.66478461,-7.7183358e-08,-0.74703616};
 	};
 };
 binarizationWanted=0;
@@ -329,7 +329,7 @@ class CustomAttributes
 		class Attribute0
 		{
 			property="ENH_AddObjectsToZeus";
-			expression="        if (!is3DEN && isServer && _value) then        {            private _objects = allMissionObjects '';            allCurators apply {_x addCuratorEditableObjects [_objects, true]};            addMissionEventHandler ['EntityCreated',            {                params ['_entity'];                allCurators apply {_x addCuratorEditableObjects [[_entity], true]};            }];        }";
+			expression="        if (_value isEqualType true) then {_value = 2};        if (!is3DEN && isServer && _value > 0) then        {            _value spawn" \n "            {" \n "                params ['_value'];" \n "                waitUntil {sleep 1; allCurators isNotEqualTo []};" \n "                if (_value == 1 || _value == 2) then                {                    allCurators apply {_x addCuratorEditableObjects [allMissionObjects '', true]};                };                if (_value == 2) then                {                    addMissionEventHandler ['EntityCreated',                    {                        params ['_entity'];                        allCurators apply {_x addCuratorEditableObjects [[_entity], true]};                    }];                };            };        }";
 			class Value
 			{
 				class data
@@ -383,13 +383,14 @@ class Mission
 					dataType="Object";
 					class PositionInfo
 					{
-						position[]={8058.8506,29.594358,10164.392};
-						angles[]={0,1.3761106,-0};
+						position[]={8058.8511,29.594358,10164.392};
+						angles[]={0,1.3761048,0};
 					};
 					side="West";
 					flags=7;
 					class Attributes
 					{
+						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						description="Mission Commander [Required]";
 						isPlayer=1;
 						isPlayable=1;
@@ -433,13 +434,14 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8058.3994,29.595207,10161.94};
-						angles[]={0,1.2663641,-0};
+						angles[]={0,1.2663641,0};
 					};
 					side="West";
 					flags=5;
 					class Attributes
 					{
 						skill=0.40000001;
+						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=149;
@@ -451,7 +453,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8056.7402,29.620411,10158.225};
-						angles[]={0,0.95437723,-0};
+						angles[]={0,0.95437723,0};
 					};
 					side="West";
 					flags=5;
@@ -459,6 +461,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
+						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=150;
@@ -471,13 +474,14 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8058.0693,29.596848,10160.223};
-						angles[]={0,1.2663641,-0};
+						angles[]={0,1.2663641,0};
 					};
 					side="West";
 					flags=5;
 					class Attributes
 					{
 						skill=0.40000001;
+						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=151;
@@ -490,13 +494,14 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8057.1875,29.596411,10161.647};
-						angles[]={0,1.2663641,-0};
+						angles[]={0,1.2663641,0};
 					};
 					side="West";
 					flags=5;
 					class Attributes
 					{
 						rank="SERGEANT";
+						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=152;
@@ -508,7 +513,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8057.666,29.607416,10158.321};
-						angles[]={0,1.2663641,-0};
+						angles[]={0,1.2663641,0};
 					};
 					side="West";
 					flags=5;
@@ -516,6 +521,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
+						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=153;
@@ -528,13 +534,14 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8056.9585,29.599447,10159.951};
-						angles[]={0,1.2663641,-0};
+						angles[]={0,1.2663641,0};
 					};
 					side="West";
 					flags=5;
 					class Attributes
 					{
 						skill=0.40000001;
+						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=154;
@@ -547,13 +554,14 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8057.4526,29.595476,10163.515};
-						angles[]={0,1.2663641,-0};
+						angles[]={0,1.2663641,0};
 					};
 					side="West";
 					flags=5;
 					class Attributes
 					{
 						skill=0.40000001;
+						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=155;
@@ -651,7 +659,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8100.1553,30.442177,10161.318};
-				angles[]={-0,4.8685269,6.2816415};
+				angles[]={0,4.8685269,6.2816415};
 			};
 			side="Empty";
 			flags=4;
@@ -686,7 +694,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8100.7271,30.513704,10173.138};
-				angles[]={-0,4.3608656,6.2807932};
+				angles[]={0,4.3608656,6.2807932};
 			};
 			side="Empty";
 			flags=4;
@@ -789,7 +797,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8079.7539,29.559999,10186.136};
-				angles[]={-0,4.7802792,0};
+				angles[]={0,4.7802792,0};
 			};
 			side="Empty";
 			class Attributes
@@ -804,7 +812,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8086.1343,31.785885,10158.679};
-				angles[]={-0,4.8152609,6.282495};
+				angles[]={0,4.8152609,6.282495};
 			};
 			side="Empty";
 			flags=4;
@@ -853,7 +861,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8088.2861,31.735531,10142.561};
-				angles[]={-0,4.7677579,6.282495};
+				angles[]={0,4.7677579,6.282495};
 			};
 			side="Empty";
 			flags=4;
@@ -870,7 +878,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8091.6294,31.762644,10151.183};
-				angles[]={-0,4.7924175,6.282495};
+				angles[]={0,4.7924175,6.282495};
 			};
 			side="Empty";
 			flags=4;
@@ -887,7 +895,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8057.1572,29.594275,10162.525};
-				angles[]={-0,1.8259988,6.282495};
+				angles[]={0,1.8259988,6.282495};
 			};
 			name="respawnPoint2";
 			id=52;
@@ -968,7 +976,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8088.5195,29.559183,10153.846};
-				angles[]={-0,1.1269488,6.282495};
+				angles[]={0,1.1269488,6.282495};
 			};
 			id=53;
 			type="ModuleRespawnVehicle_F";
@@ -1113,7 +1121,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8085.8193,29.560026,10196.815};
-				angles[]={-0,1.0819336,0};
+				angles[]={0,1.0819336,0};
 			};
 			id=54;
 			type="ModuleRespawnVehicle_F";
@@ -1259,7 +1267,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8099.0474,29.962317,10165.216};
-				angles[]={-0,5.0200472,6.282495};
+				angles[]={0,5.0200472,6.282495};
 			};
 			side="Empty";
 			flags=4;
@@ -1294,7 +1302,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8100.9756,29.996351,10170.907};
-				angles[]={-0,4.6260166,6.2807932};
+				angles[]={0,4.6260166,6.2807932};
 			};
 			side="Empty";
 			flags=4;
@@ -1329,7 +1337,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8086.6333,29.670706,10185.851};
-				angles[]={-0,1.0819412,0};
+				angles[]={0,1.0819412,0};
 			};
 			side="Empty";
 			flags=4;
@@ -1346,7 +1354,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8076.332,29.670679,10192.688};
-				angles[]={-0,1.0819368,0};
+				angles[]={0,1.0819368,0};
 			};
 			side="Empty";
 			flags=4;
@@ -1378,7 +1386,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8090.7305,29.668095,10192.228};
-				angles[]={-0,1.0819465,6.282495};
+				angles[]={0,1.0819465,6.282495};
 			};
 			side="Empty";
 			flags=4;
@@ -1427,7 +1435,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8062.8145,30.673824,10161.856};
-				angles[]={0,4.2675591,-0};
+				angles[]={0,4.2675591,0};
 			};
 			side="Empty";
 			flags=5;
@@ -1460,7 +1468,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8096.9253,30.636274,10136.173};
-				angles[]={0,2.5040061,-0};
+				angles[]={0,2.5040061,0};
 			};
 			side="Empty";
 			flags=5;
@@ -1477,7 +1485,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8055.6167,30.669287,10234.988};
-				angles[]={0,0.61436719,-0};
+				angles[]={0,0.61436719,0};
 			};
 			side="Empty";
 			flags=5;
@@ -1494,7 +1502,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8063.5298,30.6828,10233.797};
-				angles[]={0,5.3867331,-0};
+				angles[]={0,5.3867331,0};
 			};
 			side="Empty";
 			flags=5;
@@ -1511,7 +1519,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8101.1167,30.650883,10162.42};
-				angles[]={0,2.5834103,-0};
+				angles[]={0,2.5834103,0};
 			};
 			side="Empty";
 			flags=5;
@@ -1528,7 +1536,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8105.3833,30.720825,10188.174};
-				angles[]={0,2.0988326,-0};
+				angles[]={0,2.0988326,0};
 			};
 			side="Empty";
 			flags=5;
@@ -1545,7 +1553,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8101.6729,30.514893,10169.09};
-				angles[]={-0,1.847023,6.2807932};
+				angles[]={0,1.847023,6.2807932};
 			};
 			side="Empty";
 			flags=4;
@@ -1613,7 +1621,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8098.8447,30.522573,10164.987};
-				angles[]={-0,5.203907,6.282495};
+				angles[]={0,5.203907,6.282495};
 			};
 			side="Empty";
 			flags=4;
@@ -1647,7 +1655,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8100.4492,30.468037,10165.167};
-				angles[]={-0,5.7034173,6.2807932};
+				angles[]={0,5.7034173,6.2807932};
 			};
 			side="Empty";
 			flags=4;
@@ -1681,7 +1689,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8098.9805,30.778503,10164.709};
-				angles[]={-0,3.762881,6.282495};
+				angles[]={0,3.762881,6.282495};
 			};
 			side="Empty";
 			class Attributes
@@ -1715,7 +1723,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8100.8706,30.595852,10171.025};
-				angles[]={-0,1.0706687,6.2807932};
+				angles[]={0,1.0706687,6.2807932};
 			};
 			side="Empty";
 			flags=4;
@@ -1750,7 +1758,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8100.8735,30.400867,10170.604};
-				angles[]={-0,2.0011301,6.2807932};
+				angles[]={0,2.0011301,6.2807932};
 			};
 			side="Empty";
 			class Attributes
@@ -1784,7 +1792,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8100.728,31.062359,10170.554};
-				angles[]={-0,1.2950201,6.2807932};
+				angles[]={0,1.2950201,6.2807932};
 			};
 			side="Empty";
 			class Attributes
@@ -1941,7 +1949,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8061.2422,30.439228,10159.977};
-						angles[]={0,5.0060558,-0};
+						angles[]={0,5.0060558,0};
 					};
 					side="Empty";
 					flags=5;
@@ -1976,7 +1984,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8053.8374,29.915255,10165.154};
-						angles[]={-0,3.2996223,6.282495};
+						angles[]={0,3.2996223,6.282495};
 					};
 					side="Empty";
 					flags=4;
@@ -2011,7 +2019,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8053.7456,30.477659,10155.499};
-						angles[]={0,1.0790648,-0};
+						angles[]={0,1.0790648,0};
 					};
 					side="Empty";
 					flags=5;
@@ -2047,7 +2055,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8057.6724,30.439404,10168.155};
-						angles[]={0,0.031867508,-0};
+						angles[]={0,0.031867508,0};
 					};
 					side="Empty";
 					flags=5;
@@ -2083,7 +2091,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8055.4063,30.02524,10166.612};
-						angles[]={-0,1.4627185,6.282495};
+						angles[]={0,1.4627185,6.282495};
 					};
 					side="Empty";
 					flags=4;
@@ -2263,7 +2271,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8053.502,30.443399,10167.534};
-						angles[]={0,5.2678556,-0};
+						angles[]={0,5.2678556,0};
 					};
 					side="Empty";
 					flags=5;
@@ -2298,7 +2306,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8052.7178,30.444027,10165.813};
-						angles[]={0,5.0060558,-0};
+						angles[]={0,5.0060558,0};
 					};
 					side="Empty";
 					flags=5;
@@ -2333,7 +2341,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8051.9849,30.447849,10158.457};
-						angles[]={0,1.8644633,-0};
+						angles[]={0,1.8644633,0};
 					};
 					side="Empty";
 					flags=5;
@@ -2368,7 +2376,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8052.5723,30.469496,10156.996};
-						angles[]={0,3.876874,-0};
+						angles[]={0,3.876874,0};
 					};
 					side="Empty";
 					flags=5;
@@ -2404,7 +2412,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8052.293,30.44611,10160.322};
-						angles[]={0,1.6026635,-0};
+						angles[]={0,1.6026635,0};
 					};
 					side="Empty";
 					flags=5;
@@ -2439,7 +2447,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8051.395,30.564516,10163.102};
-						angles[]={-0,1.6027591,6.282495};
+						angles[]={0,1.6027591,6.282495};
 					};
 					side="Empty";
 					flags=4;
@@ -2545,7 +2553,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8082.8149,30.431194,10077.979};
-						angles[]={0,4.723989,-0};
+						angles[]={0,4.723989,0};
 					};
 					side="Empty";
 					flags=5;
@@ -2580,7 +2588,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8095.0249,30.384708,10074.461};
-						angles[]={0,4.723989,-0};
+						angles[]={0,4.723989,0};
 					};
 					side="Empty";
 					flags=5;
@@ -2616,7 +2624,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8089.4512,31.772221,10078.777};
-						angles[]={0,0.011600077,-0};
+						angles[]={0,0.011600077,0};
 					};
 					side="Empty";
 					flags=5;
@@ -2722,7 +2730,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8090.9824,30.387838,10070.884};
-						angles[]={0,0.011600077,-0};
+						angles[]={0,0.011600077,0};
 					};
 					side="Empty";
 					flags=5;
@@ -2757,7 +2765,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8086.2368,30.417194,10071.19};
-						angles[]={0,3.4149923,-0};
+						angles[]={0,3.4149923,0};
 					};
 					side="Empty";
 					flags=5;
@@ -2793,7 +2801,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8084.499,30.423353,10071.937};
-						angles[]={0,3.6767919,-0};
+						angles[]={0,3.6767919,0};
 					};
 					side="Empty";
 					flags=5;
@@ -2869,7 +2877,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8058.1099,30.769171,10166.608};
-				angles[]={-0,6.2270155,6.282495};
+				angles[]={0,6.2270155,6.282495};
 			};
 			side="Empty";
 			flags=4;
@@ -3033,7 +3041,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8061.3721,30.679029,10157.106};
-				angles[]={0,5.7985659,-0};
+				angles[]={0,5.7985659,0};
 			};
 			side="Empty";
 			flags=5;
@@ -3116,7 +3124,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8062.2671,30.832676,10278.896};
-				angles[]={0,0.10448284,-0};
+				angles[]={0,0.10448284,0};
 			};
 			side="Empty";
 			class Attributes
@@ -3124,7 +3132,7 @@ class Mission
 			};
 			id=138;
 			type="TargetP_Inf9_F";
-			atlOffset=0.34229851;
+			atlOffset=0.34229469;
 		};
 		class Item58
 		{
@@ -3216,7 +3224,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8038.5259,29.607048,10174.484};
-				angles[]={-0,2.4238069,0};
+				angles[]={0,2.4238069,0};
 			};
 			name="heliSupport";
 			id=144;
@@ -3336,7 +3344,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8036.6328,29.6,10184.67};
-				angles[]={-0,2.423852,0};
+				angles[]={0,2.423852,0};
 			};
 			id=146;
 			type="SupportProvider_Virtual_CAS_Bombing";
@@ -3656,12 +3664,13 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8056.2407,29.596445,10164.944};
-						angles[]={0,1.3761101,-0};
+						angles[]={0,1.3761101,0};
 					};
 					side="West";
 					flags=7;
 					class Attributes
 					{
+						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=168;
@@ -3673,13 +3682,14 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8055.7896,29.596855,10162.492};
-						angles[]={0,1.2663641,-0};
+						angles[]={0,1.2663641,0};
 					};
 					side="West";
 					flags=5;
 					class Attributes
 					{
 						skill=0.40000001;
+						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=169;
@@ -3692,7 +3702,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8054.375,29.606394,10158.828};
-						angles[]={0,0.95437723,-0};
+						angles[]={0,0.95437723,0};
 					};
 					side="West";
 					flags=5;
@@ -3700,6 +3710,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
+						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=170;
@@ -3712,13 +3723,14 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8055.4585,29.598495,10160.773};
-						angles[]={0,1.2663641,-0};
+						angles[]={0,1.2663641,0};
 					};
 					side="West";
 					flags=5;
 					class Attributes
 					{
 						skill=0.40000001;
+						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=171;
@@ -3731,13 +3743,14 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8054.5767,29.598059,10162.2};
-						angles[]={0,1.2663641,-0};
+						angles[]={0,1.2663641,0};
 					};
 					side="West";
 					flags=5;
 					class Attributes
 					{
 						rank="SERGEANT";
+						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=172;
@@ -3749,7 +3762,7 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8055.3525,29.607586,10158.973};
-						angles[]={0,1.2663641,-0};
+						angles[]={0,1.2663641,0};
 					};
 					side="West";
 					flags=5;
@@ -3757,6 +3770,7 @@ class Mission
 					{
 						skill=0.44999999;
 						rank="CORPORAL";
+						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=173;
@@ -3769,13 +3783,14 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8054.3481,29.599598,10160.504};
-						angles[]={0,1.2663641,-0};
+						angles[]={0,1.2663641,0};
 					};
 					side="West";
 					flags=5;
 					class Attributes
 					{
 						skill=0.40000001;
+						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=174;
@@ -3788,13 +3803,14 @@ class Mission
 					class PositionInfo
 					{
 						position[]={8054.8862,29.59753,10163.895};
-						angles[]={0,1.2663641,-0};
+						angles[]={0,1.2663641,0};
 					};
 					side="West";
 					flags=5;
 					class Attributes
 					{
 						skill=0.40000001;
+						init="if (isPlayer this == false) then {" \n "_actionID = this addAction [ " \n "    ""Modify Loadout"",  " \n "    { " \n "     [_this select 0, _this select 1, _this select 2, _this select 3] remoteExec ['DHO_fnc_setUnitLoadout', _this select 1]; " \n "    }, " \n "    nil, " \n "    1.5, " \n "    true, " \n "    true, " \n "    """", " \n "    ""(_target distance (getMarkerPos 'mainBase')) < 500"" " \n "   ];" \n "};";
 						isPlayable=1;
 					};
 					id=175;
@@ -3847,7 +3863,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8079.8906,29.559999,10186.042};
-				angles[]={-0,4.7824121,0};
+				angles[]={0,4.7824121,0};
 			};
 			side="Empty";
 			flags=4;
@@ -3897,7 +3913,7 @@ class Mission
 			class PositionInfo
 			{
 				position[]={8101.1167,30.516203,10167.302};
-				angles[]={-0,1.4331937,6.2807932};
+				angles[]={0,1.4331937,6.2807932};
 			};
 			side="Empty";
 			flags=4;


### PR DESCRIPTION
It's time for the 2025 Spooki Season update, just in time for Halloween! This update adds a new mission type, anomaly zones in random areas (in addition to normal cities and towns), a bunch of quality of life additions for people playing solo, and some vital bugfixes for base game changes that have broken parts of the mission. Some more detail:

**New Mission: Boss Monster**
Added a new mission type which will spawn a 'boss' monster from the EnemySpawnBoss pool generated in the mod loader. Once the boss monster is eliminated, the zone will be completed. The boss is set to a 'level' equal to the number of players divided by 4, and then modified by the difficulty selection in the parameters. This update resolves parts of Issues #6 and #11 

**Random Anomaly Zones**
Added the ability for DHO to spawn zones in random wilderness areas (instead of just named locations, as before). This will enable more flexibility to create interesting dynamic scenarios and allow ops to take place not only in urban areas.

**Solo/Single Player Quality of Life**
This adds a check for someone playing DHO by themselves (SP, MP self hosted, or dedicated). If true, a squad of friendly AI soldiers is spawned to support the solo player. Those AI can also have their loadouts modified using the "Modify Unit Loadout" scroll wheel option at the POG Base. These were highly requested features and help resolve Issue #10

**Vital Bug Fixes**
**Helicopter Issues**
As per issue #12, the insertion helicopter in spawn has developed an issue with not conducting any other waypoints after the initial insertion. After countless hours attempting to fix this bug (which appears to have been caused by a recent Arma 3 update), I have created a work around which simply replaces the crew with new units and a new group each time it lands. This creates more edge case bugs to deal with down the road, but for now this essential feature is restored. As issue #12 is also present in the Helicopter Support module, I have replaced that module with the virtual module until I can work with the BI devs to get this functionality working again.

**Dynamic Simulation Issues**
As per issue #13, many units are not having their simulation reenabled by dynamicSim when the players get close, leading to "frozen" monsters. This was especially true for any boss type monsters, thus ruining that mission type. To resolve this, I have created a workaround that involves a large trigger manually reenabling all simulation on every unit when a player comes near a zone. This is a bandaid that will need some refining in future passes.

_That's all of the updates for Dynamic Horror Ops v0.34! I hope you have a fantastic time getting spooked with your friends this year! As always, please leave feedback on the workshop or on the scenario github at https://github.com/UselessFodder/FS-DynamicHorrorOp . Thanks and happy hunting!_

**Changelog:**
Adds:
- New DHO_fnc_spawnBoss function (within Zone/fn_spawnBoss.sqf) generates a 'boss' type monster from the EnemySpawnBoss list and places it in the specified location
- New DHO_fnc_createNewLocation function will generate a FlatArea type location somewhere on the map in a location that is on the ground and not within the NearRadius to another point.
- Check to init.sqf if only one player is active. If so, it spawns a number of friendly AI soldiers from a hard coded list based on the difficulty (8 AI for easy or normal, 6 for hard, and 4 for Nightmare).
- DHO_fnc_setUnitLoadout is a new function that allows editing of an AI unit's loadout. Under the hood, it works by saving the player's current loadout, then copying the targeted unit's loadout to the player, then finally opening the arsenal. Once the player makes changes and closes the arsenal, the player unit's loadout is copied onto the targeted unit, then the player's loadout is restored. This is primarily activated by an addAction on the targeted unit that only works within 500m of the main base area.
- New function DHO_fn_heliInsert that handles the helicopter insertion as a separate function that can be remoteExec'd

Changes:
- Added Case 3 (Destroy Boss) to fn_createTask.sqf to generate boss missions and supporting triggers, tasks, etc.
- Added _missionType selection of 3 to fn_initLocation.sqf to ensure boss type missions are generated
- Enhanced task data to show proper images or indicate if no preview image is available.
- init.sqf now generates a number of random locations equal to 10% of the named locations
- DHO_fn_findLocation now also searches for FlatArea type locations
- Now deletes all non-player units in SP mode
- Check in init.sqf to spawn friendly AI modified FROM only multiplayer TO any time there is only one player (including SP). This will ensure that newly renamed Modify Unit Loadout addAction is only applied to AI units.
- Ensured enableDynamicSimulation is run on all groups AND units spawned
- Modified DHO_fnc_initLocation to create a trigger area that manually disables DynamicSim and manually reenables simulation on all units in the area.
- Modified helicopter insertion script to delete the previous crew and replace with a new crew 30 second after landing at home base. This is to fix the issue outlined in issue #12
- Removed the init lines from each soldier (a leftover accidentally not fixed from v0.33a)

Bugfixes:
- Added a check to boss's lifeState in addition to an isNull check for some bosses that don't go 'null' upon defeat (namely Empires of Old)
- AI units spawned in player hosted MP were getting unreliable spawn locations from BIS_fnc_findSafePos. Changed to simply spawn the units within 1m of the MissionCommander
- Changed addAction to a remoteExec so single players on dedicated servers correctly get the added action. Previously, only the player who was server in self-hosted games would get it.

TODO / Known Issues:
- Balance Boss levels
- Consider deleting all other enemies of boss type within zone to remove confusion.
- Consider adding a check to delete soldiers if a second player JIP
- Consider adding AI respawn when player RTBs
- Better random location naming system
- Fix file description comment for DHO_fnc_createNewLocation
- Add parameters to allow 3 generation modes: Only cities, only wilderness, or Both
- Consider adding an addAction to player units to allow them to modify loadout anywhere within the HomeBase area.
- Clean up this horrendous bandaid code in the helicopter fixes
- Remove lots of debug logging
- Soooooo many edge cases to resolve
- Clean up code in dynamic sim fix, possibly move into separate function
- Performance (lots of new triggers polling)
- Consider modifying overall spawn code to utilize trigger to spawn all units into the area only when players are around (will help overall performance for servers at the cost of a lag spike when players near zone)